### PR TITLE
fix: my last testing of the day

### DIFF
--- a/.github/workflows/release2.yml
+++ b/.github/workflows/release2.yml
@@ -1,91 +1,85 @@
-name: Branch Tagging2
+name: Release from PR
 on:
   pull_request:
     types:
-      - closed  # Runs only when a PR is closed (merged or not)
-    branches:
-      - main
+      - closed
 
 permissions:
-  contents: write  # Required for pushing tags and creating releases  
+  contents: write  # Required for pushing tags and creating releases
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true  # Ensures it runs only if PR is merged
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Parse PR for Release Information
+      - name: Extract PR Information
         id: parse_pr
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
           PR_BODY: "${{ github.event.pull_request.body }}"
         run: |
-          # Extract release title from PR
-          if [[ "$PR_TITLE" =~ Release.*:\ *(.*) ]]; then
-            FEATURE_TITLE="${BASH_REMATCH[1]}"
+          # Extract version number and title from PR title
+          if [[ "$PR_TITLE" =~ Release[[:space:]]([0-9]+\.[0-9]+):[[:space:]](.*) ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            FEATURE_TITLE="${BASH_REMATCH[2]}"
           else
+            VERSION="0.0.1"
             FEATURE_TITLE="Production Update"
           fi
 
           # Extract "What's New" section from PR body
-          WHATS_NEW=$(echo "$PR_BODY" | awk '/## What'\''s New/{flag=1; next} /## /{flag=0} flag')
+          WHATS_NEW=$(echo "$PR_BODY" | awk '/## What'\''s New/{flag=1; next} /## /{flag=0} flag' | sed '/^$/d')
 
-          # Fallback message if no "What's New" section is found
           if [[ -z "$WHATS_NEW" ]]; then
-            WHATS_NEW="No significant updates mentioned in the PR."
+            WHATS_NEW="No detailed updates were provided in the PR."
           fi
 
+          echo "version=$VERSION" >> $GITHUB_ENV
           echo "feature_title=$FEATURE_TITLE" >> $GITHUB_ENV
           echo "whats_new<<EOF" >> $GITHUB_ENV
           echo "$WHATS_NEW" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Generate Release Notes
+        id: generate_notes
         run: |
-          VERSION="${{ steps.tag_version.outputs.new_tag }}"
+          VERSION="${{ env.version }}"
           FEATURE_TITLE="${{ env.feature_title }}"
           WHATS_NEW="${{ env.whats_new }}"
 
           cat > release_notes.md << EOF
           # Release Notes - Version $VERSION: $FEATURE_TITLE
           ## Overview
-          This release includes updates to the E-Vote electronic voting system. Below are the key updates for version $VERSION.
-          ---
+          This release includes updates based on the merged pull request.
+
           ## Version $VERSION: $FEATURE_TITLE
           ### What's New:
           $WHATS_NEW
+
           ---
           ## How to Use
           ### Admins:
-          1. Log in to create elections under **New Election**.
-          2. Configure settings, upload candidates, and share the generated link.
-          3. Monitor results in the **Elections Dashboard**.
+          - Log in to create elections under **New Election**.
+          - Configure settings, upload candidates, and share the generated link.
+          - Monitor results in the **Elections Dashboard**.
+
           ### Voters:
-          1. Click the election link during voting hours.
-          2. Select candidate(s) and submit.
+          - Click the election link during voting hours.
+          - Select candidate(s) and submit.
+
           ---
           ## Footer
-          <p style="text-align: center; color: #6c757d; font-size: 14px;">
-            &copy; $(date +"%Y") Resolve. All rights reserved.<br>
-            <a href="https://github.com/hngprojects/E-Vote-FE/releases" style="color: #007bff; text-decoration: none;" target="_blank" rel="noopener noreferrer">
-              View All Release Notes
-            </a>
-          </p>
+          &copy; $(date +"%Y") Resolve. All rights reserved.  
+          [View All Release Notes](https://github.com/hngprojects/E-Vote-FE/releases)
           EOF
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: "E-Vote v${{ steps.tag_version.outputs.new_tag }}: ${{ env.feature_title }}"
+          tag: "v${{ env.version }}"
+          name: "E-Vote v${{ env.version }}: ${{ env.feature_title }}"
           bodyFile: release_notes.md
           draft: false
           prerelease: false


### PR DESCRIPTION
Developer submits a PR using the provided template.
When the PR is merged, GitHub Actions triggers.
The workflow extracts only the PR content (title & body).
The release note is published exactly as written in the PR.