### PR TITLE
feat(ci): Remove release notes transfer to EC2 and store on GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to EC2
 
 on:
   push:
-   branches: 
-     - main
+    branches: 
+      - main
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # This ensures we get the full history for PR detection
+          fetch-depth: 0  # Ensures full history for PR detection
           
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -29,7 +29,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Execute the ES module script with Node
-          node --input-type=module .github/workflows/generate-release-note.js
+          node --input-type=module .github/workflows/generate-release-note.js | tee release-notes.md
+          
+      - name: Upload Release Notes as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-notes
+          path: release-notes.md
           
       - name: Set up SSH key
         run: |
@@ -40,9 +46,6 @@ jobs:
           
       - name: Deploy to EC2
         run: |
-          # Copy release notes to the server
-          scp -o StrictHostKeyChecking=no release-notes.md ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USERNAME }}/myapp/
-          
           ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
             # Define application directory
             APP_DIR="/home/${{ secrets.EC2_USERNAME }}/myapp"


### PR DESCRIPTION
# **Remove Release Notes Transfer to EC2 and Store on GitHub**

This PR removes the step that transferred release notes to the EC2 instance and instead uploads the release notes as an artifact within GitHub Actions.

## **New Features**
- Introduced an artifact upload step to store `release-notes.md` within GitHub Actions.

## **Improvements**
- Removed the unnecessary SCP step that copied release notes to EC2.
- Ensured release notes remain available in GitHub without affecting deployment.

## **Technical Requirements**
- No additional dependencies or configuration changes needed.
- Release notes can now be accessed from the "Artifacts" section in GitHub Actions.

## **Known Limitations**
- Release notes are not automatically published anywhere (e.g., GitHub Releases).
- Requires manual download from GitHub Actions if needed.

## **What's Coming**
- Future improvements may include:
  - Automating release notes publication to GitHub Releases.
  - Adding Slack/Teams notifications for new releases.
  - Configurable storage options for release notes.

Resolves #51
